### PR TITLE
Implement web scraping for week plans and photo albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ PostgreSQL, with a planned web UI and notification dispatcher.
 | `SKOLEINTRA_LOGIN_TYPE` | `uni` (UNI-Login, default) or `alm` (ordinary login) |
 | `SKOLEINTRA_PHOTOS_NOT_OLDER_THAN` | Optional cutoff date (`YYYY-MM-DD`) for photo blob downloads |
 | `SKOLEINTRA_PHOTO_RETENTION_DAYS` | Optional retention window for stored photo blobs |
+| `SKOLEINTRA_SCRAPE_RESPONSE_CACHE_SECONDS` | Optional cache window for reusing scrape detail-page responses across runs | `900` |
 
 ### Optional
 

--- a/skoleintra/db/migrations/versions/d8a4c6f1b2e0_photo_album_item_type_split.py
+++ b/skoleintra/db/migrations/versions/d8a4c6f1b2e0_photo_album_item_type_split.py
@@ -1,0 +1,51 @@
+"""photo_album_item_type_split
+
+Revision ID: d8a4c6f1b2e0
+Revises: b4c9d2e7f1a3
+Create Date: 2026-05-05 11:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d8a4c6f1b2e0"
+down_revision: Union[str, Sequence[str], None] = "b4c9d2e7f1a3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE items SET type = 'photo_album' WHERE type = 'photo'")
+    op.execute(
+        """
+        UPDATE notification_settings
+        SET type = 'photo_album'
+        WHERE type = 'photo'
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO notification_settings (type, email_enabled, ntfy_enabled, ntfy_topic)
+        SELECT 'photo', email_enabled, ntfy_enabled, ntfy_topic
+        FROM notification_settings
+        WHERE type = 'photo_album'
+          AND NOT EXISTS (
+              SELECT 1 FROM notification_settings WHERE type = 'photo'
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM notification_settings WHERE type = 'photo'")
+    op.execute(
+        """
+        UPDATE notification_settings
+        SET type = 'photo'
+        WHERE type = 'photo_album'
+        """
+    )
+    op.execute("UPDATE items SET type = 'photo' WHERE type = 'photo_album'")

--- a/skoleintra/notifications/dispatcher.py
+++ b/skoleintra/notifications/dispatcher.py
@@ -34,6 +34,7 @@ DEFAULT_NOTIFICATION_TYPES = (
     "homework",
     "document",
     "photo",
+    "photo_album",
     "weekplan",
 )
 
@@ -456,14 +457,14 @@ def _with_retries(
 
 def _subject_for(item: Item) -> str:
     title = _clean_text(item.title, default="(untitled)")
-    item_type = _clean_text(item.type, default="item")
+    item_type = _display_type_for_item(item)
     return f"[Skoleintra:{item_type}] {title}"
 
 
 def _plain_text_for(item: Item) -> str:
     title = _clean_text(item.title, default="(untitled)")
     sender = _clean_text(item.sender, default="unknown")
-    item_type = _clean_text(item.type, default="item")
+    item_type = _display_type_for_item(item)
     body_txt = _body_text_from_html(item.body_html)
 
     lines = [
@@ -486,7 +487,7 @@ def _plain_text_for(item: Item) -> str:
 def _ntfy_markdown_for(item: Item) -> str:
     title = _clean_text(item.title, default="(untitled)")
     sender = _clean_text(item.sender, default="unknown")
-    item_type = _clean_text(item.type, default="item")
+    item_type = _display_type_for_item(item)
     body_txt = _body_text_from_html(item.body_html)
 
     meta_parts = [f"`{item_type}`", sender]
@@ -513,6 +514,7 @@ def _ntfy_tags_for_item(item: Item) -> list[str]:
         "homework": ["books", "school"],
         "document": ["page_facing_up", "school"],
         "photo": ["camera", "school"],
+        "photo_album": ["camera", "school"],
         "weekplan": ["calendar", "school"],
     }
     return type_tags.get(item_type, ["bell", "school"])
@@ -543,6 +545,13 @@ def _clean_text(value: str | None, default: str) -> str:
     normalized = html.unescape(value).replace("\xa0", " ")
     collapsed = _collapse_ws(normalized)
     return collapsed or default
+
+
+def _display_type_for_item(item: Item) -> str:
+    item_type = _clean_text(item.type, default="item").lower()
+    return {
+        "photo_album": "photo album",
+    }.get(item_type, item_type)
 
 
 def _format_mobile_date(iso_value: str) -> str:

--- a/skoleintra/scraper/__init__.py
+++ b/skoleintra/scraper/__init__.py
@@ -78,6 +78,7 @@ def run_scrape(
     )
 
     s3_client = get_s3_client(settings)
+    cache_ttl_seconds = max(0, settings.scrape_response_cache_seconds or 0) or None
 
     # ------------------------------------------------------------------
     # Login
@@ -157,7 +158,11 @@ def run_scrape(
 
             # Messages
             try:
-                scraped_items = messages_scraper.scrape(portal, child_url_prefix)
+                scraped_items = messages_scraper.scrape(
+                    portal,
+                    child_url_prefix,
+                    cache_ttl_seconds=cache_ttl_seconds,
+                )
             except Exception as exc:
                 msg = f"[{child_name}] messages scraper failed: {exc}"
                 logger.error(msg)
@@ -170,7 +175,11 @@ def run_scrape(
 
             # Photos
             try:
-                photo_items = photos_scraper.scrape(portal, child_url_prefix)
+                photo_items = photos_scraper.scrape(
+                    portal,
+                    child_url_prefix,
+                    cache_ttl_seconds=cache_ttl_seconds,
+                )
                 scraped_items.extend(photo_items)
             except Exception as exc:
                 msg = f"[{child_name}] photos scraper failed: {exc}"
@@ -183,7 +192,11 @@ def run_scrape(
 
             # Week plans
             try:
-                weekplan_items = weekplans_scraper.scrape(portal, child_url_prefix)
+                weekplan_items = weekplans_scraper.scrape(
+                    portal,
+                    child_url_prefix,
+                    cache_ttl_seconds=cache_ttl_seconds,
+                )
                 scraped_items.extend(weekplan_items)
             except Exception as exc:
                 msg = f"[{child_name}] weekplans scraper failed: {exc}"

--- a/skoleintra/scraper/__init__.py
+++ b/skoleintra/scraper/__init__.py
@@ -26,6 +26,7 @@ from skoleintra.scraper.children import get_child_snapshots
 from skoleintra.scraper.login import login
 from skoleintra.scraper.pages import messages as messages_scraper
 from skoleintra.scraper.pages import photos as photos_scraper
+from skoleintra.scraper.pages import weekplans as weekplans_scraper
 from skoleintra.scraper.session import PortalSession
 from skoleintra.settings import Settings
 
@@ -178,6 +179,19 @@ def run_scrape(
                 if debug:
                     portal.save_debug_artifact(
                         f"{child_name}_photos_error.html", str(exc)
+                    )
+
+            # Week plans
+            try:
+                weekplan_items = weekplans_scraper.scrape(portal, child_url_prefix)
+                scraped_items.extend(weekplan_items)
+            except Exception as exc:
+                msg = f"[{child_name}] weekplans scraper failed: {exc}"
+                logger.error(msg)
+                result.errors.append(msg)
+                if debug:
+                    portal.save_debug_artifact(
+                        f"{child_name}_weekplans_error.html", str(exc)
                     )
 
             for scraped in scraped_items:

--- a/skoleintra/scraper/pages/messages.py
+++ b/skoleintra/scraper/pages/messages.py
@@ -25,7 +25,12 @@ logger = logging.getLogger(__name__)
 ITEM_TYPE = "message"
 
 
-def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
+def scrape(
+    portal: PortalSession,
+    child_url_prefix: str,
+    *,
+    cache_ttl_seconds: int | None = None,
+) -> list[ScrapedItem]:
     """Fetch and parse all messages for one child.
 
     Parameters
@@ -60,7 +65,13 @@ def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
             logger.debug("Skipping conversation with no LatestMessageId: %r", conv)
             continue
 
-        msgs = _load_thread(portal, child_url_prefix, thread_id, latest_mid)
+        msgs = _load_thread(
+            portal,
+            child_url_prefix,
+            thread_id,
+            latest_mid,
+            cache_ttl_seconds=cache_ttl_seconds,
+        )
         for raw_msg in msgs:
             item = _msg_to_scraped_item(raw_msg, thread_id)
             if item is not None:
@@ -100,6 +111,8 @@ def _load_thread(
     child_url_prefix: str,
     thread_id: str,
     latest_mid: str,
+    *,
+    cache_ttl_seconds: int | None = None,
 ) -> list[dict]:
     """Load the full message list for a conversation thread."""
     if thread_id:
@@ -119,7 +132,7 @@ def _load_thread(
     url = f"{child_url_prefix}{suffix}"
     logger.debug("Loading thread from %s", url)
     try:
-        resp = portal.get(url)
+        resp = portal.get(url, cache_ttl_seconds=cache_ttl_seconds)
         data = json.loads(resp.text)
     except Exception as exc:
         logger.warning("Could not load thread %s/%s: %s", thread_id, latest_mid, exc)

--- a/skoleintra/scraper/pages/photos.py
+++ b/skoleintra/scraper/pages/photos.py
@@ -8,6 +8,7 @@ actual image URLs under ``/file/photoalbum/<album-id>/...``.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
 from datetime import datetime, timezone
@@ -19,10 +20,16 @@ from skoleintra.scraper.session import PortalSession
 
 logger = logging.getLogger(__name__)
 
+ALBUM_ITEM_TYPE = "photo_album"
 ITEM_TYPE = "photo"
 
 
-def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
+def scrape(
+    portal: PortalSession,
+    child_url_prefix: str,
+    *,
+    cache_ttl_seconds: int | None = None,
+) -> list[ScrapedItem]:
     """Scrape photo albums for one child and return them as ``ScrapedItem`` rows."""
     url = f"{child_url_prefix}/photos/albums"
     logger.info("Fetching photo albums from %s", url)
@@ -51,7 +58,7 @@ def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
         album_author = _album_author(album_link)
 
         try:
-            album_resp = portal.get(album_url)
+            album_resp = portal.get(album_url, cache_ttl_seconds=cache_ttl_seconds)
         except Exception as exc:
             logger.warning("Failed to fetch photo album %s: %s", album_url, exc)
             continue
@@ -73,22 +80,36 @@ def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
             body_parts.append(f"<p>{album_description}</p>")
         body_html = "\n".join(body_parts) + "\n"
 
+        album_raw = {
+            "album_url": album_url,
+            "count": len(image_urls),
+            "description": album_description,
+            "author": album_author,
+        }
+
         items.append(
             ScrapedItem(
-                type=ITEM_TYPE,
+                type=ALBUM_ITEM_TYPE,
                 external_id=external_id,
-                title=f"Photos: {album_name}",
+                title=f"Photo album: {album_name}",
                 sender=album_author or "SkoleIntra",
                 body_html=body_html,
                 date=date,
-                raw_json={
-                    "album_url": album_url,
-                    "count": len(image_urls),
-                    "description": album_description,
-                    "author": album_author,
-                },
-                attachments=attachments,
+                raw_json=album_raw,
             )
+        )
+        items.extend(
+            ScrapedItem(
+                type=ITEM_TYPE,
+                external_id=f"{external_id}:{attachment.url}",
+                title=f"Photo: {album_name}",
+                sender=album_author or "SkoleIntra",
+                body_html=body_html,
+                date=date,
+                raw_json={**album_raw, "photo_url": attachment.url},
+                attachments=[attachment],
+            )
+            for attachment in attachments
         )
 
     logger.info("Found %d photo album item(s) for %s", len(items), child_url_prefix)
@@ -98,6 +119,41 @@ def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
 def _extract_image_urls(soup: BeautifulSoup, portal: PortalSession) -> list[str]:
     urls: list[str] = []
     seen: set[str] = set()
+
+    for gallery in soup.find_all(
+        attrs={
+            "data-clientlogic-settings-photoalbum": True,
+        }
+    ):
+        payload = (
+            gallery.get("data-clientlogic-settings-photoalbum")
+            or gallery.get("data-clientlogic-settings-PhotoAlbum")
+            or ""
+        ).strip()
+        if not payload:
+            continue
+
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+
+        items = parsed.get("GalleryModel", {}).get("Items", [])
+        if not isinstance(items, list):
+            continue
+
+        for entry in items:
+            if not isinstance(entry, dict):
+                continue
+            src = str(entry.get("Source") or "").strip()
+            if not src:
+                continue
+            abs_url = portal.abs_url(src)
+            if "/file/photoalbum/" not in abs_url or abs_url in seen:
+                continue
+            seen.add(abs_url)
+            urls.append(abs_url)
+
     for img in soup.select("img"):
         src = (img.get("src") or "").strip()
         if not src or src.startswith("data:"):

--- a/skoleintra/scraper/pages/weekplans.py
+++ b/skoleintra/scraper/pages/weekplans.py
@@ -19,7 +19,12 @@ logger = logging.getLogger(__name__)
 ITEM_TYPE = "weekplan"
 
 
-def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
+def scrape(
+    portal: PortalSession,
+    child_url_prefix: str,
+    *,
+    cache_ttl_seconds: int | None = None,
+) -> list[ScrapedItem]:
     """Scrape published week plans for one child."""
     url = f"{child_url_prefix}item/weeklyplansandhomework/list"
     logger.info("Fetching week plans from %s", url)
@@ -39,7 +44,7 @@ def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
             continue
 
         try:
-            detail_resp = portal.get(plan_url)
+            detail_resp = portal.get(plan_url, cache_ttl_seconds=cache_ttl_seconds)
         except Exception as exc:
             logger.warning("Failed to fetch week plan %s: %s", plan_url, exc)
             continue

--- a/skoleintra/scraper/pages/weekplans.py
+++ b/skoleintra/scraper/pages/weekplans.py
@@ -1,0 +1,250 @@
+"""Week plan scraper for ForaeldreIntra."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from html import escape
+
+from bs4 import BeautifulSoup
+
+from skoleintra.scraper.models import ScrapedAttachment, ScrapedItem
+from skoleintra.scraper.session import PortalSession
+
+logger = logging.getLogger(__name__)
+
+ITEM_TYPE = "weekplan"
+
+
+def scrape(portal: PortalSession, child_url_prefix: str) -> list[ScrapedItem]:
+    """Scrape published week plans for one child."""
+    url = f"{child_url_prefix}item/weeklyplansandhomework/list"
+    logger.info("Fetching week plans from %s", url)
+    resp = portal.get(url)
+    soup = BeautifulSoup(resp.text, "lxml")
+
+    items: list[ScrapedItem] = []
+    seen_urls: set[str] = set()
+    for plan_link in soup.select("ul.sk-weekly-plans-list-container a[href]"):
+        plan_url = portal.abs_url((plan_link.get("href") or "").strip())
+        if not plan_url or plan_url in seen_urls:
+            continue
+        seen_urls.add(plan_url)
+
+        if not plan_url.startswith(child_url_prefix):
+            logger.debug("Skipping out-of-scope week plan URL: %s", plan_url)
+            continue
+
+        try:
+            detail_resp = portal.get(plan_url)
+        except Exception as exc:
+            logger.warning("Failed to fetch week plan %s: %s", plan_url, exc)
+            continue
+
+        item = _scraped_item_from_detail(detail_resp.text, plan_url)
+        if item is not None:
+            items.append(item)
+
+    logger.info("Found %d week plan item(s) for %s", len(items), child_url_prefix)
+    return items
+
+
+def _scraped_item_from_detail(page_html: str, plan_url: str) -> ScrapedItem | None:
+    selected_plan = _selected_plan_from_html(page_html)
+    if selected_plan is None:
+        return None
+
+    visible_sections = _visible_sections(selected_plan)
+    plan_attachments = _plan_attachments(selected_plan)
+    if not visible_sections and not plan_attachments:
+        return None
+
+    group_name = str(selected_plan.get("ClassOrGroup") or "SkoleIntra")
+    formatted_week = str(selected_plan.get("FormattedWeek") or "")
+    external_id = _external_id_for(selected_plan, plan_url)
+    title = _title_for(group_name, formatted_week, external_id)
+
+    attachments = [
+        attachment
+        for _, lesson_plans in visible_sections
+        for lesson_plan in lesson_plans
+        for attachment in _lesson_plan_attachments(lesson_plan)
+    ]
+    attachments.extend(plan_attachments)
+
+    return ScrapedItem(
+        type=ITEM_TYPE,
+        external_id=external_id,
+        title=title,
+        sender=group_name,
+        body_html=_body_html_for(title, visible_sections),
+        date=_date_for(selected_plan),
+        raw_json=_raw_json_for(selected_plan, plan_url),
+        attachments=attachments,
+    )
+
+
+def _selected_plan_from_html(page_html: str) -> dict | None:
+    soup = BeautifulSoup(page_html, "lxml")
+    root = soup.select_one("#root")
+    if root is None:
+        return None
+
+    raw = None
+    for attr_name, attr_value in root.attrs.items():
+        if attr_name.lower() == "data-clientlogic-settings-weeklyplansapp":
+            raw = attr_value
+            break
+    if not isinstance(raw, str) or not raw:
+        return None
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+    selected_plan = payload.get("SelectedPlan")
+    return selected_plan if isinstance(selected_plan, dict) else None
+
+
+def _visible_sections(selected_plan: dict) -> list[tuple[str, list[dict]]]:
+    sections: list[tuple[str, list[dict]]] = []
+
+    general_plan = selected_plan.get("GeneralPlan")
+    if isinstance(general_plan, dict):
+        lesson_plans = _visible_lesson_plans(general_plan)
+        if lesson_plans:
+            sections.append(("Generelt", lesson_plans))
+
+    for daily_plan in selected_plan.get("DailyPlans") or []:
+        if not isinstance(daily_plan, dict):
+            continue
+        lesson_plans = _visible_lesson_plans(daily_plan)
+        if not lesson_plans:
+            continue
+        sections.append((str(daily_plan.get("Day") or "Dag"), lesson_plans))
+
+    return sections
+
+
+def _visible_lesson_plans(plan: dict) -> list[dict]:
+    lesson_plans: list[dict] = []
+    for lesson_plan in plan.get("LessonPlans") or []:
+        if not isinstance(lesson_plan, dict):
+            continue
+        if lesson_plan.get("IsDraft"):
+            continue
+        lesson_plans.append(lesson_plan)
+    return lesson_plans
+
+
+def _body_html_for(title: str, sections: list[tuple[str, list[dict]]]) -> str:
+    parts = [f"<h2>{escape(title)}</h2>"]
+    for section_title, lesson_plans in sections:
+        parts.append("<section>")
+        parts.append(f"<h3>{escape(section_title)}</h3>")
+        for lesson_plan in lesson_plans:
+            subject = _subject_for(lesson_plan)
+            if subject:
+                parts.append(f"<h4>{escape(subject)}</h4>")
+            content = str(lesson_plan.get("Content") or "").strip()
+            if content:
+                parts.append(content)
+        parts.append("</section>")
+    return "\n".join(parts)
+
+
+def _subject_for(lesson_plan: dict) -> str:
+    subject = lesson_plan.get("Subject")
+    if not isinstance(subject, dict):
+        return ""
+    return str(
+        subject.get("FormattedTitle") or subject.get("Title") or "Uden angivelse af fag"
+    )
+
+
+def _lesson_plan_attachments(lesson_plan: dict) -> list[ScrapedAttachment]:
+    attachments: list[ScrapedAttachment] = []
+    for entry in lesson_plan.get("Attachments") or []:
+        attachment = _attachment_from_entry(entry)
+        if attachment is not None:
+            attachments.append(attachment)
+
+    link = str(lesson_plan.get("Link") or "").strip()
+    if link:
+        attachments.append(
+            ScrapedAttachment(
+                filename=_subject_for(lesson_plan) or "Link",
+                url=link,
+            )
+        )
+    return attachments
+
+
+def _plan_attachments(selected_plan: dict) -> list[ScrapedAttachment]:
+    attachments: list[ScrapedAttachment] = []
+    for entry in selected_plan.get("Attachments") or []:
+        attachment = _attachment_from_entry(entry)
+        if attachment is not None:
+            attachments.append(attachment)
+    return attachments
+
+
+def _attachment_from_entry(entry: object) -> ScrapedAttachment | None:
+    if not isinstance(entry, dict):
+        return None
+    url = str(entry.get("Uri") or "").strip()
+    if not url:
+        return None
+    filename = str(entry.get("FileName") or url).strip() or url
+    return ScrapedAttachment(filename=filename, url=url)
+
+
+def _date_for(selected_plan: dict) -> datetime | None:
+    for daily_plan in selected_plan.get("DailyPlans") or []:
+        if not isinstance(daily_plan, dict):
+            continue
+        raw = str(daily_plan.get("Date") or "").strip()
+        if not raw:
+            continue
+        try:
+            return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def _external_id_for(selected_plan: dict, plan_url: str) -> str:
+    formatted_week = str(selected_plan.get("FormattedWeek") or "").strip()
+    match = re.fullmatch(r"(\d{1,2})-(\d{4})", formatted_week)
+    if match:
+        week, year = match.groups()
+        return f"{year}-W{int(week):02d}"
+
+    plan_date = _date_for(selected_plan)
+    if plan_date is not None:
+        iso_year, iso_week, _ = plan_date.isocalendar()
+        return f"{iso_year}-W{iso_week:02d}"
+
+    return hashlib.sha1(plan_url.encode("utf-8")).hexdigest()
+
+
+def _title_for(group_name: str, formatted_week: str, external_id: str) -> str:
+    match = re.fullmatch(r"(\d{1,2})-(\d{4})", formatted_week)
+    if match:
+        week, _ = match.groups()
+        return f"Ugeplan for {group_name} - uge {int(week)}"
+    return f"Ugeplan for {group_name} - {external_id}"
+
+
+def _raw_json_for(selected_plan: dict, plan_url: str) -> dict:
+    raw = {
+        key: value
+        for key, value in selected_plan.items()
+        if key not in {"HistoryData", "StudentName"}
+    }
+    raw["plan_url"] = plan_url
+    return raw

--- a/skoleintra/scraper/session.py
+++ b/skoleintra/scraper/session.py
@@ -7,9 +7,12 @@ authenticated session without re-logging in every time.
 import logging
 import os
 import pickle
+import time
+from hashlib import sha1
 from typing import Any
 
 import requests
+from requests.structures import CaseInsensitiveDict
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +53,15 @@ class PortalSession:
         os.makedirs(self.state_dir, exist_ok=True)
         return os.path.join(self.state_dir, f"{self.hostname}.cookies")
 
+    def _response_cache_dir(self) -> str:
+        path = os.path.join(self.state_dir, "response-cache")
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def _response_cache_path(self, url: str) -> str:
+        digest = sha1(url.encode("utf-8")).hexdigest()
+        return os.path.join(self._response_cache_dir(), f"{digest}.pickle")
+
     def _load_cookies(self) -> None:
         path = self._cookie_path()
         if os.path.isfile(path):
@@ -81,13 +93,22 @@ class PortalSession:
             return path
         return f"https://{self.hostname}{path}"
 
-    def get(self, url: str, **kwargs: Any) -> requests.Response:
+    def get(
+        self, url: str, *, cache_ttl_seconds: int | None = None, **kwargs: Any
+    ) -> requests.Response:
         """Perform a GET request against the portal with default headers and timeout."""
         url = self.abs_url(url)
         logger.debug("GET %s", url)
+        if cache_ttl_seconds is not None:
+            cached = self._load_cached_response(url, cache_ttl_seconds)
+            if cached is not None:
+                logger.debug("GET cache hit %s", url)
+                return cached
         kwargs.setdefault("timeout", _REQUEST_TIMEOUT)
         resp = self._session.get(url, **kwargs)
         resp.raise_for_status()
+        if cache_ttl_seconds is not None:
+            self._store_cached_response(url, resp)
         return resp
 
     def post(self, url: str, **kwargs: Any) -> requests.Response:
@@ -114,3 +135,52 @@ class PortalSession:
                 fh.write(content)
         logger.info("Debug artifact saved to %s", path)
         return path
+
+    def _load_cached_response(
+        self, url: str, cache_ttl_seconds: int
+    ) -> requests.Response | None:
+        path = self._response_cache_path(url)
+        if not os.path.isfile(path):
+            return None
+        try:
+            with open(path, "rb") as fh:
+                payload = pickle.load(fh)
+        except Exception as exc:
+            logger.warning("Could not load response cache %s: %s", path, exc)
+            return None
+
+        cached_at = payload.get("cached_at")
+        if not isinstance(cached_at, (int, float)):
+            return None
+        if time.time() - cached_at > cache_ttl_seconds:
+            return None
+
+        response = requests.Response()
+        response.status_code = int(payload.get("status_code", 200))
+        response.url = str(payload.get("url") or url)
+        self._set_response_content(response, payload.get("content") or b"")
+        response.headers = CaseInsensitiveDict(payload.get("headers") or {})
+        response.encoding = payload.get("encoding")
+        return response
+
+    def _store_cached_response(self, url: str, response: requests.Response) -> None:
+        path = self._response_cache_path(url)
+        payload = {
+            "cached_at": time.time(),
+            "url": response.url,
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+            "content": response.content,
+            "encoding": response.encoding,
+        }
+        try:
+            with open(path, "wb") as fh:
+                pickle.dump(payload, fh)
+        except Exception as exc:
+            logger.warning("Could not store response cache %s: %s", path, exc)
+
+    @staticmethod
+    def _set_response_content(response: requests.Response, content: bytes) -> None:
+        # requests.Response has no public constructor for preloaded bodies.
+        # Rehydrating the cached payload requires setting the internal buffer.
+        response._content = content  # pylint: disable=protected-access

--- a/skoleintra/settings.py
+++ b/skoleintra/settings.py
@@ -86,6 +86,9 @@ class Settings(BaseSettings):
     photos_not_older_than: str = Field(default="")
     photo_retention_days: int | None = None
 
+    # Response cache for repeated scrape runs
+    scrape_response_cache_seconds: int = 900
+
 
 def get_settings() -> Settings:
     """Build a fresh settings object from the current environment."""

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,19 @@
+from skoleintra.db.models import Item
+from skoleintra.notifications.dispatcher import _ntfy_markdown_for, _subject_for
+
+
+def test_photo_album_notifications_use_domain_label():
+    item = Item(
+        type="photo_album",
+        title="Photo album: Classroom week 19",
+        sender="Teacher Example",
+        body_html="<p>Classroom week 19</p><p>Photos: 2</p><p>Outdoor crafts.</p>",
+    )
+
+    assert (
+        _subject_for(item) == "[Skoleintra:photo album] Photo album: Classroom week 19"
+    )
+    assert _ntfy_markdown_for(item).splitlines()[:2] == [
+        "**Photo album: Classroom week 19**",
+        "`photo album` • Teacher Example",
+    ]

--- a/tests/test_photo_features.py
+++ b/tests/test_photo_features.py
@@ -11,6 +11,7 @@ from skoleintra.scraper.pages.photos import (
     _album_title,
     _extract_date,
     _extract_image_urls,
+    scrape,
 )
 
 
@@ -70,3 +71,121 @@ def test_album_metadata_and_photo_image_filtering():
 
     urls = _extract_image_urls(soup, DummyPortal())
     assert urls == ["https://example.test/file/photoalbum/6216/1000011430.jpg?t=123"]
+
+
+def test_scrape_returns_photo_album_and_individual_photos():
+    albums_html = """
+        <ul id="sk-photos-albums-content-container" class="sk-list padding-15">
+            <li>
+                <div>
+                    <div class="h-fl-l h-width-90">
+                        <a href="/parent/9999/Child/photos/albums/album/photos/6254" class="sk-photoalbums-list-item">
+                            <div class="sk-photoalbum-list-item-cover-image">
+                                <div style="background : url('/file/photoalbum/6254/IMG_1001.jpeg?t=1');"></div>
+                            </div>
+                            <div class="sk-photoalbum-list-item-description-block">
+                                <div class="sk-photoalbum-list-item-title">
+                                    Classroom week 19
+                                </div>
+                                <div class="sk-photoalbum-list-item-description">
+                                    Outdoor crafts and forest snacks.
+                                </div>
+                                <div class="sk-photoalbum-list-item-author">Oprettet af: Teacher Example</div>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+            </li>
+        </ul>
+    """
+    album_html = """
+        <div class="sk-photoalbums" data-clientlogic-settings-PhotoAlbum='{"GalleryModel":{"Items":[
+            {"Source":"/file/photoalbum/6254/IMG_1001.jpeg?t=1","Description":"IMG_1001.jpeg"},
+            {"Source":"/file/photoalbum/6254/IMG_1002.jpeg?t=2","Description":"IMG_1002.jpeg"}
+        ]}}'></div>
+        <div class="h-ta-c">Classroom week 19</div>
+        <div class="h-ta-c">Group Blue</div>
+        <div class="sk-photoalbums-list">
+            <ul class="h-hlist">
+                <li>
+                    <div class="sk-photoalbum-image-thumbnail">
+                        <div>
+                            <a href="/parent/9999/Child/photos/albums/album/6254/0?category=Group+Blue">
+                                <img src="/file/photoalbum/6254/IMG_1001.jpeg?t=1"/>
+                            </a>
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="sk-photoalbum-image-thumbnail">
+                        <div>
+                            <a href="/parent/9999/Child/photos/albums/album/6254/1?category=Group+Blue">
+                                <img src="/file/photoalbum/6254/IMG_1002.jpeg?t=2"/>
+                            </a>
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    """
+
+    class DummyResponse:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class DummyPortal:
+        def get(self, url: str, **_kwargs) -> DummyResponse:
+            if url.endswith("/photos/albums"):
+                return DummyResponse(albums_html)
+            if url.endswith("/photos/albums/album/photos/6254"):
+                return DummyResponse(album_html)
+            raise AssertionError(url)
+
+        def abs_url(self, path: str) -> str:
+            if path.startswith("http"):
+                return path
+            return f"https://example.test{path}"
+
+    items = scrape(DummyPortal(), "https://example.test/parent/9999/Child")
+
+    assert [item.type for item in items] == ["photo_album", "photo", "photo"]
+    assert items[0].external_id == "6254"
+    assert items[0].title == "Photo album: Classroom week 19"
+    assert items[0].sender == "Teacher Example"
+    assert items[0].raw_json == {
+        "album_url": "https://example.test/parent/9999/Child/photos/albums/album/photos/6254",
+        "count": 2,
+        "description": "Outdoor crafts and forest snacks.",
+        "author": "Teacher Example",
+    }
+    assert items[1].external_id == (
+        "6254:https://example.test/file/photoalbum/6254/IMG_1001.jpeg?t=1"
+    )
+    assert items[1].title == "Photo: Classroom week 19"
+    assert items[1].attachments[0].url == (
+        "https://example.test/file/photoalbum/6254/IMG_1001.jpeg?t=1"
+    )
+    assert items[2].external_id == (
+        "6254:https://example.test/file/photoalbum/6254/IMG_1002.jpeg?t=2"
+    )
+
+
+def test_extract_image_urls_uses_gallery_model_items():
+    html = """
+        <div class="sk-photoalbums" data-clientlogic-settings-PhotoAlbum='{"GalleryModel":{"Items":[
+            {"Source":"/file/photoalbum/6254/IMG_1001.jpeg?t=1","Description":"IMG_1001.jpeg"},
+            {"Source":"/file/photoalbum/6254/IMG_1002.jpeg?t=2","Description":"IMG_1002.jpeg"}
+        ]}}'></div>
+    """
+    soup = BeautifulSoup(html, "lxml")
+
+    class DummyPortal:
+        def abs_url(self, path: str) -> str:
+            if path.startswith("http"):
+                return path
+            return f"https://example.test{path}"
+
+    assert _extract_image_urls(soup, DummyPortal()) == [
+        "https://example.test/file/photoalbum/6254/IMG_1001.jpeg?t=1",
+        "https://example.test/file/photoalbum/6254/IMG_1002.jpeg?t=2",
+    ]

--- a/tests/test_scrape_orchestration.py
+++ b/tests/test_scrape_orchestration.py
@@ -1,0 +1,83 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import skoleintra.scraper as scraper_module
+from skoleintra.db.identity import ChildSnapshot
+from skoleintra.scraper.models import ScrapedItem
+from skoleintra.settings import Settings
+
+
+def test_run_scrape_includes_weekplan_items(monkeypatch):
+    upserted_types: list[str] = []
+
+    class DummyPortal:
+        def __init__(self, hostname: str, state_dir: str) -> None:
+            self.hostname = hostname
+            self.state_dir = state_dir
+
+    @contextmanager
+    def fake_session_scope():
+        yield object()
+
+    monkeypatch.setattr(scraper_module, "PortalSession", DummyPortal)
+    monkeypatch.setattr(scraper_module, "get_s3_client", lambda settings: None)
+    monkeypatch.setattr(scraper_module, "login", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        scraper_module,
+        "get_child_snapshots",
+        lambda portal, soup: [
+            ChildSnapshot(
+                source_id="child-1",
+                display_name="Freja Example",
+                url_prefix="https://school.example.test/parent/1234/Freja",
+            )
+        ],
+    )
+    monkeypatch.setattr(scraper_module, "session_scope", fake_session_scope)
+    monkeypatch.setattr(scraper_module, "prune_photo_blobs", lambda session, days: 0)
+    monkeypatch.setattr(
+        scraper_module,
+        "sync_child_scope",
+        lambda session, school_hostname, discovered, scope_succeeded: [
+            SimpleNamespace(id=1, source_id="child-1")
+        ],
+    )
+    monkeypatch.setattr(scraper_module.messages_scraper, "scrape", lambda *args: [])
+    monkeypatch.setattr(scraper_module.photos_scraper, "scrape", lambda *args: [])
+    monkeypatch.setattr(
+        scraper_module.weekplans_scraper,
+        "scrape",
+        lambda *args: [
+            ScrapedItem(
+                type="weekplan",
+                external_id="2026-W19",
+                title="Ugeplan for Mellemtrin A - uge 19",
+                sender="Mellemtrin A",
+                body_html="<p>Bring boots.</p>",
+                date=None,
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        scraper_module,
+        "upsert_item",
+        lambda session, child, scraped: (
+            upserted_types.append(scraped.type) or SimpleNamespace(id=1),
+            True,
+        ),
+    )
+    monkeypatch.setattr(scraper_module, "upsert_attachment", lambda *args: None)
+    monkeypatch.setattr(scraper_module, "download_pending_attachments", lambda *args: 0)
+
+    result = scraper_module.run_scrape(
+        Settings(
+            database_url="postgresql+psycopg://localhost/skoleintra",
+            hostname="school.example.test",
+            username="parent",
+            password="secret",
+        )
+    )
+
+    assert upserted_types == ["weekplan"]
+    assert result.items_new == 1
+    assert result.items_updated == 0

--- a/tests/test_scrape_orchestration.py
+++ b/tests/test_scrape_orchestration.py
@@ -42,12 +42,16 @@ def test_run_scrape_includes_weekplan_items(monkeypatch):
             SimpleNamespace(id=1, source_id="child-1")
         ],
     )
-    monkeypatch.setattr(scraper_module.messages_scraper, "scrape", lambda *args: [])
-    monkeypatch.setattr(scraper_module.photos_scraper, "scrape", lambda *args: [])
+    monkeypatch.setattr(
+        scraper_module.messages_scraper, "scrape", lambda *args, **kwargs: []
+    )
+    monkeypatch.setattr(
+        scraper_module.photos_scraper, "scrape", lambda *args, **kwargs: []
+    )
     monkeypatch.setattr(
         scraper_module.weekplans_scraper,
         "scrape",
-        lambda *args: [
+        lambda *args, **kwargs: [
             ScrapedItem(
                 type="weekplan",
                 external_id="2026-W19",
@@ -81,3 +85,77 @@ def test_run_scrape_includes_weekplan_items(monkeypatch):
     assert upserted_types == ["weekplan"]
     assert result.items_new == 1
     assert result.items_updated == 0
+
+
+def test_run_scrape_passes_response_cache_ttl_to_scrapers(monkeypatch):
+    seen_cache_ttls: list[int | None] = []
+
+    class DummyPortal:
+        def __init__(self, hostname: str, state_dir: str) -> None:
+            self.hostname = hostname
+            self.state_dir = state_dir
+
+    @contextmanager
+    def fake_session_scope():
+        yield object()
+
+    monkeypatch.setattr(scraper_module, "PortalSession", DummyPortal)
+    monkeypatch.setattr(scraper_module, "get_s3_client", lambda settings: None)
+    monkeypatch.setattr(scraper_module, "login", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        scraper_module,
+        "get_child_snapshots",
+        lambda portal, soup: [
+            ChildSnapshot(
+                source_id="child-1",
+                display_name="Freja Example",
+                url_prefix="https://school.example.test/parent/1234/Freja",
+            )
+        ],
+    )
+    monkeypatch.setattr(scraper_module, "session_scope", fake_session_scope)
+    monkeypatch.setattr(scraper_module, "prune_photo_blobs", lambda session, days: 0)
+    monkeypatch.setattr(
+        scraper_module,
+        "sync_child_scope",
+        lambda session, school_hostname, discovered, scope_succeeded: [
+            SimpleNamespace(id=1, source_id="child-1")
+        ],
+    )
+    monkeypatch.setattr(
+        scraper_module.messages_scraper,
+        "scrape",
+        lambda *args, **kwargs: seen_cache_ttls.append(kwargs.get("cache_ttl_seconds"))
+        or [],
+    )
+    monkeypatch.setattr(
+        scraper_module.photos_scraper,
+        "scrape",
+        lambda *args, **kwargs: seen_cache_ttls.append(kwargs.get("cache_ttl_seconds"))
+        or [],
+    )
+    monkeypatch.setattr(
+        scraper_module.weekplans_scraper,
+        "scrape",
+        lambda *args, **kwargs: seen_cache_ttls.append(kwargs.get("cache_ttl_seconds"))
+        or [],
+    )
+    monkeypatch.setattr(
+        scraper_module,
+        "upsert_item",
+        lambda session, child, scraped: (SimpleNamespace(id=1), True),
+    )
+    monkeypatch.setattr(scraper_module, "upsert_attachment", lambda *args: None)
+    monkeypatch.setattr(scraper_module, "download_pending_attachments", lambda *args: 0)
+
+    scraper_module.run_scrape(
+        Settings(
+            database_url="postgresql+psycopg://localhost/skoleintra",
+            hostname="school.example.test",
+            username="parent",
+            password="secret",
+            scrape_response_cache_seconds=900,
+        )
+    )
+
+    assert seen_cache_ttls == [900, 900, 900]

--- a/tests/test_scrape_response_cache.py
+++ b/tests/test_scrape_response_cache.py
@@ -1,0 +1,162 @@
+from pathlib import Path
+
+import requests
+
+from skoleintra.scraper.pages import messages as messages_scraper
+from skoleintra.scraper.pages import photos as photos_scraper
+from skoleintra.scraper.pages import weekplans as weekplans_scraper
+from skoleintra.scraper.session import PortalSession
+
+
+def _response(url: str, body: str) -> requests.Response:
+    response = requests.Response()
+    response.status_code = 200
+    response.url = url
+    response._content = body.encode("utf-8")  # pylint: disable=protected-access
+    response.headers["Content-Type"] = "text/html; charset=utf-8"
+    response.encoding = "utf-8"
+    return response
+
+
+def test_photo_scrape_reuses_cached_album_pages_across_runs(tmp_path, monkeypatch):
+    albums_html = """
+        <ul id="sk-photos-albums-content-container" class="sk-list padding-15">
+            <li>
+                <a href="/parent/9999/Child/photos/albums/album/photos/6254" class="sk-photoalbums-list-item">
+                    <div class="sk-photoalbum-list-item-title">Classroom week 19</div>
+                    <div class="sk-photoalbum-list-item-description">Outdoor crafts.</div>
+                    <div class="sk-photoalbum-list-item-author">Oprettet af: Teacher Example</div>
+                </a>
+            </li>
+        </ul>
+    """
+    album_html = """
+        <div class="sk-photoalbums" data-clientlogic-settings-PhotoAlbum='{"GalleryModel":{"Items":[
+            {"Source":"/file/photoalbum/6254/IMG_1001.jpeg?t=1","Description":"IMG_1001.jpeg"}
+        ]}}'></div>
+        <div class="h-ta-c">Classroom week 19</div>
+    """
+    counts: dict[str, int] = {}
+
+    def fake_get(self, url, **kwargs):  # pylint: disable=unused-argument
+        counts[url] = counts.get(url, 0) + 1
+        if url.endswith("/photos/albums"):
+            return _response(url, albums_html)
+        if url.endswith("/photos/albums/album/photos/6254"):
+            return _response(url, album_html)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(requests.Session, "get", fake_get)
+
+    state_dir = str(tmp_path / "state")
+    child_url_prefix = "https://example.test/parent/9999/Child"
+
+    first_portal = PortalSession("example.test", state_dir)
+    second_portal = PortalSession("example.test", state_dir)
+
+    first_items = photos_scraper.scrape(
+        first_portal, child_url_prefix, cache_ttl_seconds=900
+    )
+    second_items = photos_scraper.scrape(
+        second_portal, child_url_prefix, cache_ttl_seconds=900
+    )
+
+    assert len(first_items) == 2
+    assert len(second_items) == 2
+    assert counts == {
+        f"{child_url_prefix}/photos/albums": 2,
+        f"{child_url_prefix}/photos/albums/album/photos/6254": 1,
+    }
+    cache_files = list((Path(state_dir) / "response-cache").glob("*"))
+    assert cache_files
+
+
+def test_message_scrape_reuses_cached_thread_pages_across_runs(tmp_path, monkeypatch):
+    messages_html = """
+        <div class="sk-l-content-wrapper">
+            <div data-messages='{"Conversations":[{"ThreadId":"thread-1","LatestMessageId":"1001"}]}'></div>
+        </div>
+    """
+    thread_html = """
+        [{"Id":"1001","Subject":"Hello","SenderName":"Teacher Example","BaseText":"Hi there","PreviousMessagesText":"","SentReceivedDateText":"05/05/2026 12:00","AttachmentsLinks":[]}]
+    """
+    counts: dict[str, int] = {}
+
+    def fake_get(self, url, **kwargs):  # pylint: disable=unused-argument
+        counts[url] = counts.get(url, 0) + 1
+        if url.endswith("/messages/conversations"):
+            return _response(url, messages_html)
+        if "loadmessagesforselectedconversation" in url:
+            return _response(url, thread_html)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(requests.Session, "get", fake_get)
+
+    state_dir = str(tmp_path / "state")
+    child_url_prefix = "https://example.test/parent/9999/Child"
+
+    first_portal = PortalSession("example.test", state_dir)
+    second_portal = PortalSession("example.test", state_dir)
+
+    first_items = messages_scraper.scrape(
+        first_portal, child_url_prefix, cache_ttl_seconds=900
+    )
+    second_items = messages_scraper.scrape(
+        second_portal, child_url_prefix, cache_ttl_seconds=900
+    )
+
+    assert [item.external_id for item in first_items] == ["thread-1--1001"]
+    assert [item.external_id for item in second_items] == ["thread-1--1001"]
+    assert counts == {
+        f"{child_url_prefix}/messages/conversations": 2,
+        f"{child_url_prefix}/messages/conversations/loadmessagesforselectedconversation?threadId=thread-1&takeFromRootMessageId=1001&takeToMessageId=0&searchRequest=": 1,
+    }
+
+
+def test_weekplan_scrape_reuses_cached_detail_pages_across_runs(tmp_path, monkeypatch):
+    list_html = """
+        <ul class="sk-weekly-plans-list-container">
+            <li>
+                <a href="/parent/9999/Childitem/weeklyplansandhomework/item/class/19-2026">Uge 19</a>
+            </li>
+        </ul>
+    """
+    detail_html = """
+        <div id="root" data-clientlogic-settings-weeklyplansapp='{"SelectedPlan":{
+            "FormattedWeek":"19-2026",
+            "ClassOrGroup":"Class Blue",
+            "DailyPlans":[{"Day":"Mandag","Date":"2026-05-04","LessonPlans":[{"Content":"Bring boots.","Subject":{"Title":"Tur"},"Attachments":[],"IsDraft":false}]}],
+            "Attachments":[]
+        }}'></div>
+    """
+    counts: dict[str, int] = {}
+
+    def fake_get(self, url, **kwargs):  # pylint: disable=unused-argument
+        counts[url] = counts.get(url, 0) + 1
+        if url.endswith("item/weeklyplansandhomework/list"):
+            return _response(url, list_html)
+        if url.endswith("item/weeklyplansandhomework/item/class/19-2026"):
+            return _response(url, detail_html)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(requests.Session, "get", fake_get)
+
+    state_dir = str(tmp_path / "state")
+    child_url_prefix = "https://example.test/parent/9999/Child"
+
+    first_portal = PortalSession("example.test", state_dir)
+    second_portal = PortalSession("example.test", state_dir)
+
+    first_items = weekplans_scraper.scrape(
+        first_portal, child_url_prefix, cache_ttl_seconds=900
+    )
+    second_items = weekplans_scraper.scrape(
+        second_portal, child_url_prefix, cache_ttl_seconds=900
+    )
+
+    assert [item.external_id for item in first_items] == ["2026-W19"]
+    assert [item.external_id for item in second_items] == ["2026-W19"]
+    assert counts == {
+        f"{child_url_prefix}item/weeklyplansandhomework/list": 2,
+        f"{child_url_prefix}item/weeklyplansandhomework/item/class/19-2026": 1,
+    }

--- a/tests/test_weekplans_scraper.py
+++ b/tests/test_weekplans_scraper.py
@@ -21,7 +21,7 @@ class DummyPortal:
             return path
         return f"https://{self.hostname}{path}"
 
-    def get(self, url: str) -> DummyResponse:
+    def get(self, url: str, **_kwargs) -> DummyResponse:
         return DummyResponse(self._pages[self.abs_url(url)])
 
 

--- a/tests/test_weekplans_scraper.py
+++ b/tests/test_weekplans_scraper.py
@@ -1,0 +1,188 @@
+import json
+from datetime import datetime, timezone
+
+from skoleintra.scraper.pages import weekplans
+
+
+class DummyResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class DummyPortal:
+    def __init__(
+        self, pages: dict[str, str], hostname: str = "school.example.test"
+    ) -> None:
+        self._pages = pages
+        self.hostname = hostname
+
+    def abs_url(self, path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        return f"https://{self.hostname}{path}"
+
+    def get(self, url: str) -> DummyResponse:
+        return DummyResponse(self._pages[self.abs_url(url)])
+
+
+def _detail_page(selected_plan: dict) -> str:
+    payload = {"SelectedPlan": selected_plan}
+    return (
+        "<html><body>"
+        f"<div id='root' data-clientlogic-settings-WeeklyPlansApp='{json.dumps(payload)}'></div>"
+        "</body></html>"
+    )
+
+
+def test_scrape_returns_published_weekplan_with_normalized_content_and_links():
+    child_url_prefix = "https://school.example.test/parent/1234/Freja"
+    list_url = f"{child_url_prefix}item/weeklyplansandhomework/list"
+    detail_url = (
+        "https://school.example.test/parent/1234/Frejaitem/"
+        "weeklyplansandhomework/show/19-2026"
+    )
+    portal = DummyPortal(
+        {
+            list_url: """
+                <ul class="sk-weekly-plans-list-container">
+                  <li><a href="/parent/1234/Frejaitem/weeklyplansandhomework/show/19-2026">Week 19</a></li>
+                </ul>
+            """,
+            detail_url: _detail_page(
+                {
+                    "GeneralPlan": {
+                        "Date": None,
+                        "Day": None,
+                        "DayOfWeek": 0,
+                        "FormattedDate": None,
+                        "LessonPlans": [
+                            {
+                                "Subject": {
+                                    "Title": "General info",
+                                    "FormattedTitle": "General info",
+                                    "IsGeneralSubject": True,
+                                },
+                                "Content": "<p>Bring boots.</p>",
+                                "Link": "https://links.example.test/menu",
+                                "Snapshots": [],
+                                "Attachments": [
+                                    {
+                                        "FileName": "Menu PDF",
+                                        "Uri": "https://files.example.test/menu.pdf",
+                                    }
+                                ],
+                                "IsDraft": False,
+                            }
+                        ],
+                        "Schedule": None,
+                    },
+                    "DailyPlans": [
+                        {
+                            "Date": "2026-05-04",
+                            "Day": "Mandag",
+                            "DayOfWeek": 1,
+                            "FormattedDate": "4. maj",
+                            "LessonPlans": [
+                                {
+                                    "Subject": {
+                                        "Title": "Nature",
+                                        "FormattedTitle": "Nature",
+                                        "IsGeneralSubject": False,
+                                    },
+                                    "Content": "<p>Plant seeds.</p>",
+                                    "Link": "https://links.example.test/seeds",
+                                    "Snapshots": [],
+                                    "Attachments": [
+                                        {
+                                            "FileName": "Packing list",
+                                            "Uri": "https://files.example.test/list.pdf",
+                                        }
+                                    ],
+                                    "IsDraft": False,
+                                }
+                            ],
+                            "Schedule": [],
+                        }
+                    ],
+                    "FormattedWeek": "19-2026",
+                    "ClassOrGroup": "Mellemtrin A",
+                    "Attachments": [
+                        {
+                            "FileName": "Week overview",
+                            "Uri": "https://files.example.test/overview.pdf",
+                        }
+                    ],
+                }
+            ),
+        }
+    )
+
+    items = weekplans.scrape(portal, child_url_prefix)
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.type == "weekplan"
+    assert item.external_id == "2026-W19"
+    assert item.title == "Ugeplan for Mellemtrin A - uge 19"
+    assert item.sender == "Mellemtrin A"
+    assert item.date == datetime(2026, 5, 4, tzinfo=timezone.utc)
+    assert "Bring boots." in item.body_html
+    assert "Plant seeds." in item.body_html
+    assert "Generelt" in item.body_html
+    assert "Mandag" in item.body_html
+    assert [attachment.url for attachment in item.attachments] == [
+        "https://files.example.test/menu.pdf",
+        "https://links.example.test/menu",
+        "https://files.example.test/list.pdf",
+        "https://links.example.test/seeds",
+        "https://files.example.test/overview.pdf",
+    ]
+
+
+def test_scrape_ignores_draft_only_weekplans():
+    child_url_prefix = "https://school.example.test/parent/1234/Freja"
+    list_url = f"{child_url_prefix}item/weeklyplansandhomework/list"
+    detail_url = (
+        "https://school.example.test/parent/1234/Frejaitem/"
+        "weeklyplansandhomework/show/20-2026"
+    )
+    portal = DummyPortal(
+        {
+            list_url: """
+                <ul class="sk-weekly-plans-list-container">
+                  <li><a href="/parent/1234/Frejaitem/weeklyplansandhomework/show/20-2026">Week 20</a></li>
+                </ul>
+            """,
+            detail_url: _detail_page(
+                {
+                    "GeneralPlan": {
+                        "Date": None,
+                        "Day": None,
+                        "DayOfWeek": 0,
+                        "FormattedDate": None,
+                        "LessonPlans": [
+                            {
+                                "Subject": {
+                                    "Title": "General info",
+                                    "FormattedTitle": "General info",
+                                    "IsGeneralSubject": True,
+                                },
+                                "Content": "<p>Internal draft only.</p>",
+                                "Link": "",
+                                "Snapshots": [],
+                                "Attachments": [],
+                                "IsDraft": True,
+                            }
+                        ],
+                        "Schedule": None,
+                    },
+                    "DailyPlans": [],
+                    "FormattedWeek": "20-2026",
+                    "ClassOrGroup": "Mellemtrin A",
+                    "Attachments": [],
+                }
+            ),
+        }
+    )
+
+    assert not weekplans.scrape(portal, child_url_prefix)


### PR DESCRIPTION
This pull request introduces significant improvements to how photo albums and photos are handled, enhances notification clarity, and adds support for response caching and week plan scraping. The most important changes are summarized below. Closes #20 

**Photo Album and Photo Item Type Split:**

* A new item type, `photo_album`, is introduced, separating photo albums from individual photos. The scraper now creates both `photo_album` and `photo` items for each album, and a database migration updates existing data and notification settings accordingly. [[1]](diffhunk://#diff-f36d250adb0137772b76d25e7962249dc37dce5c627f3b48d530b9f133c0793cR23-R32) [[2]](diffhunk://#diff-f36d250adb0137772b76d25e7962249dc37dce5c627f3b48d530b9f133c0793cR83-R112) [[3]](diffhunk://#diff-f36d250adb0137772b76d25e7962249dc37dce5c627f3b48d530b9f133c0793cR122-R156) [[4]](diffhunk://#diff-c933950e877dfa461b51c65cbe68ee3a310afba53aadfcfe947decb9170b59e7R1-R51)

**Notification Improvements:**

* The notification dispatcher now recognizes `photo_album` as a distinct type, uses a display-friendly type name ("photo album"), and supports appropriate tags for notifications. This improves notification clarity and user experience. [[1]](diffhunk://#diff-53784e3f38a0056e7e7132c7ea58edd1a32dfe2453cca4d66736db2466e01c2aR37) [[2]](diffhunk://#diff-53784e3f38a0056e7e7132c7ea58edd1a32dfe2453cca4d66736db2466e01c2aL459-R467) [[3]](diffhunk://#diff-53784e3f38a0056e7e7132c7ea58edd1a32dfe2453cca4d66736db2466e01c2aL489-R490) [[4]](diffhunk://#diff-53784e3f38a0056e7e7132c7ea58edd1a32dfe2453cca4d66736db2466e01c2aR517) [[5]](diffhunk://#diff-53784e3f38a0056e7e7132c7ea58edd1a32dfe2453cca4d66736db2466e01c2aR550-R556)

**Scraper Enhancements:**

* The scraper now supports a configurable cache window for reusing HTTP responses, controlled by the new `SKOLEINTRA_SCRAPE_RESPONSE_CACHE_SECONDS` setting. This applies to messages, photos, and week plans. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19) [[2]](diffhunk://#diff-b5ce57b27561233e4e86b1ed8e63f8e042bb521b1bcc89968e55adc8385602d1R81) [[3]](diffhunk://#diff-7ca3e1042f61a9b3bbca96e0516e2410935e8941d92ed9fbb9c9f11bc267a5c2L28-R33) [[4]](diffhunk://#diff-7ca3e1042f61a9b3bbca96e0516e2410935e8941d92ed9fbb9c9f11bc267a5c2L63-R74) [[5]](diffhunk://#diff-7ca3e1042f61a9b3bbca96e0516e2410935e8941d92ed9fbb9c9f11bc267a5c2R114-R115) [[6]](diffhunk://#diff-7ca3e1042f61a9b3bbca96e0516e2410935e8941d92ed9fbb9c9f11bc267a5c2L122-R135) [[7]](diffhunk://#diff-f36d250adb0137772b76d25e7962249dc37dce5c627f3b48d530b9f133c0793cL54-R61)

* Scraping for week plans is added, using a new import and scrape call in the main scraper logic. [[1]](diffhunk://#diff-b5ce57b27561233e4e86b1ed8e63f8e042bb521b1bcc89968e55adc8385602d1R29) [[2]](diffhunk://#diff-b5ce57b27561233e4e86b1ed8e63f8e042bb521b1bcc89968e55adc8385602d1R193-R209)

**Other Technical Improvements:**

* The photo album scraper now parses image URLs from embedded JSON data, increasing robustness against changes in the HTML structure. [[1]](diffhunk://#diff-f36d250adb0137772b76d25e7962249dc37dce5c627f3b48d530b9f133c0793cR11) [[2]](diffhunk://#diff-f36d250adb0137772b76d25e7962249dc37dce5c627f3b48d530b9f133c0793cR122-R156)

**Database Migration:**

* An Alembic migration script updates the `items` and `notification_settings` tables to support the new `photo_album` type, including downgrade logic.